### PR TITLE
Had to correct the stlying because the previous styling had both pane…

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -214,10 +214,14 @@ ul.select2-results {
     padding: 4px 0px;
 }
 
-#f_results_nav_subpanel > .panel.panel-default {
+#f_results_nav_subpanel {
     max-height: 470px;
     overflow-y: scroll;
     overflow-x: hidden;
+}
+
+#f_results_nav_subpanel .panel.panel-default:last-of-type {
+    margin-bottom: 0 !important;
 }
 
 #select2-test-results {


### PR DESCRIPTION
Had to correct the stlying because the previous styling had both panels with its own scroll bar. It was discussed to have one scroll bar for both panels. Having to override the margin-bottom of the last panel to remove the 20px spacing on the last panel. This is noticable when you scroll to the end.